### PR TITLE
Fixed ioredis hmset allowing support for data as object

### DIFF
--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -239,9 +239,9 @@ declare namespace IORedis {
         hsetnx(key: string, field: string, value: any): Promise<0 | 1>;
 
         hget(key: string, field: string, callback: (err: Error, res: string) => void): void;
-        hget(key: string, field: string): Promise<string>;        
+        hget(key: string, field: string): Promise<string>;
         
-        hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;        
+        hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;
         hmset(key: string, data: any, callback: (err: Error, res: 0 | 1) => void): void;
         hmset(key: string, data: any): Promise<0 | 1>;
 

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -240,7 +240,7 @@ declare namespace IORedis {
 
         hget(key: string, field: string, callback: (err: Error, res: string) => void): void;
         hget(key: string, field: string): Promise<string>;
-        
+
         hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;
         hmset(key: string, data: any, callback: (err: Error, res: 0 | 1) => void): void;
         hmset(key: string, data: any): Promise<0 | 1>;

--- a/types/ioredis/index.d.ts
+++ b/types/ioredis/index.d.ts
@@ -239,9 +239,11 @@ declare namespace IORedis {
         hsetnx(key: string, field: string, value: any): Promise<0 | 1>;
 
         hget(key: string, field: string, callback: (err: Error, res: string) => void): void;
-        hget(key: string, field: string): Promise<string>;
-
-        hmset(key: string, field: string, value: any, ...args: string[]): any;
+        hget(key: string, field: string): Promise<string>;        
+        
+        hmset(key: string, field: string, value: any, ...args: string[]): Promise<0 | 1>;        
+        hmset(key: string, data: any, callback: (err: Error, res: 0 | 1) => void): void;
+        hmset(key: string, data: any): Promise<0 | 1>;
 
         hmget(key: string, field: string, ...fields: string[]): any;
 


### PR DESCRIPTION
Please fill in this template.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code. (Compile and run.)
- [X] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [X] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [X] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

If changing an existing definition:
- [X] Provide a URL to documentation or source code which provides context for the suggested changes: <<https://github.com/luin/ioredis/search?utf8=%E2%9C%93&q=hmset&type=>>

`ioredis.hmset` supports taking an object as second argument, as clearly observable in the examples provided by the tests of ioredis. Not only, it supports also `Map`s.
It also returns a Promise, or can take a callback. Neither were accepted in the current typings file.
